### PR TITLE
Fix alt tags for team photos

### DIFF
--- a/src/components/Section.jsx
+++ b/src/components/Section.jsx
@@ -107,7 +107,7 @@ function Section({ title, id, children, gradientClass }) {
                   <div className="flex justify-between items-center">
                     <Typography variant="h6">Jonathan Correa</Typography>
                     <img
-                      alt=""
+                      alt="Jonathan Correa"
                       src={foto_joni}
                       className="inline-block h-20 w-20 rounded-full ring-2 ring-white"
                     />
@@ -156,7 +156,7 @@ function Section({ title, id, children, gradientClass }) {
                   <div className="flex justify-between items-center">
                     <Typography variant="h6">Franco More</Typography>
                     <img
-                      alt=""
+                      alt="Franco More"
                       src={franco}
                       className="inline-block h-20 w-20 rounded-full ring-2 ring-white"
                     />


### PR DESCRIPTION
## Summary
- add alt text for Jonathan Correa and Franco More images

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6855e28df6d88327bd30d9b067998875