### PR TITLE
Use environment variables for configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env*
 
 # Editor directories and files
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -6,3 +6,26 @@ Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+
+## Environment Variables
+
+The application expects several environment variables to be defined in a `.env` file.
+These values are used to configure Firebase and the EmailJS service. Each variable
+is prefixed with `VITE_` so that Vite exposes it at build time.
+
+```
+VITE_FIREBASE_API_KEY=your-firebase-api-key
+VITE_FIREBASE_AUTH_DOMAIN=your-firebase-auth-domain
+VITE_FIREBASE_PROJECT_ID=your-firebase-project-id
+VITE_FIREBASE_STORAGE_BUCKET=your-firebase-storage-bucket
+VITE_FIREBASE_MESSAGING_SENDER_ID=your-firebase-messaging-sender-id
+VITE_FIREBASE_APP_ID=your-firebase-app-id
+
+VITE_EMAILJS_SERVICE_ID=your-emailjs-service-id
+VITE_EMAILJS_TEMPLATE_ID=your-emailjs-template-id
+VITE_EMAILJS_CONFIRM_TEMPLATE_ID=your-emailjs-confirm-template-id
+VITE_EMAILJS_USER_ID=your-emailjs-user-id
+```
+
+Create a `.env` file at the project root and provide values for each variable
+before running the application.

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -47,8 +47,8 @@ function Contact({ id, title }) {
         try {
             // Enviar correo al destinatario principal
             await emailjs.send(
-                "service_grmd3xg",
-                "template_3a2716m", // Reemplaza con el ID de tu plantilla
+                import.meta.env.VITE_EMAILJS_SERVICE_ID,
+                import.meta.env.VITE_EMAILJS_TEMPLATE_ID,
                 {
                     to_email: "tecnofusion.it@gmail.com", // Correo de la cuenta asociada
                     from_name: "Tecnofusión.IT",
@@ -58,20 +58,20 @@ function Contact({ id, title }) {
                     email: values.email,
                     telephone: phoneNumber,
                 },
-                "qHtG6A2I87n7CARUF"
+                import.meta.env.VITE_EMAILJS_USER_ID
             );
 
             // Enviar correo de confirmación al remitente
             await emailjs.send(
-                "service_grmd3xg",
-                "template_3mvc41r", // Reemplaza con el ID de tu plantilla
+                import.meta.env.VITE_EMAILJS_SERVICE_ID,
+                import.meta.env.VITE_EMAILJS_CONFIRM_TEMPLATE_ID,
                 {
                     to_email: values.email, // Correo del remitente
                     from_name: "Tecnofusión.IT",
                     subject: "Confirmación de envío de mensaje",
                     name: values.name,
                 },
-                "qHtG6A2I87n7CARUF"
+                import.meta.env.VITE_EMAILJS_USER_ID
             );
 
             toast.success("¡La consulta se ha enviado con éxito!");

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -2,12 +2,12 @@ import { initializeApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
 
 const firebaseConfig = {
-    apiKey: "tu-api-key",
-    authDomain: "tu-auth-domain",
-    projectId: "tu-project-id",
-    storageBucket: "tu-storage-bucket",
-    messagingSenderId: "tu-messaging-sender-id",
-    appId: "tu-app-id",
+    apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+    authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+    projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+    storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+    messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+    appId: import.meta.env.VITE_FIREBASE_APP_ID,
 };
 
 const app = initializeApp(firebaseConfig);


### PR DESCRIPTION
## Summary
- configure Firebase using `import.meta.env` values
- load EmailJS service ids from environment variables
- document required `.env` variables
- ignore `.env` files in git

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6855e29bfb04832787d0be8bd7eac8d3